### PR TITLE
Configure drug calculation coefficients from the protocol page

### DIFF
--- a/app/controllers/admin/protocols_controller.rb
+++ b/app/controllers/admin/protocols_controller.rb
@@ -63,7 +63,7 @@ class Admin::ProtocolsController < AdminController
     if @coefficients.save
       redirect_to [:admin, @coefficients], notice: "Medication list was successfully configured"
     else
-      render :configure_coefficients # renders with errors poopulated
+      render :configure_coefficients
     end
   end
 

--- a/app/controllers/admin/protocols_controller.rb
+++ b/app/controllers/admin/protocols_controller.rb
@@ -43,19 +43,11 @@ class Admin::ProtocolsController < AdminController
   end
 
   def configure_coefficients
-    @coefficients = ProtocolDrugCalculationCoefficient.find_by(protocol_params[:id]).coefficients
-    if @coefficients.absent?
-      @coefficients = {
-        "load_coefficient": 0,
-      }
-      categories = Set.new
-      @protocol.protocol_drugs.each do |drug|
-        @coefficients[drug[:rxnorm_code]] = 0
-        categories.add(drug[:drug_category])
-      end
-      categories.each do |category|
-        @coefficients[category] = 0
-      end
+    authorize { current_admin.accessible_organizations(:manage).any? }
+    @coefficients = ProtocolDrugCalculationCoefficient.find(protocol_params[:protocol_id]).coefficients
+    # should be able to just do this with new i think. check later
+    if @coefficients.blank?
+      @coefficients = ProtocolDrugCalculationCoefficient.new
     end
   end
 
@@ -74,6 +66,6 @@ class Admin::ProtocolsController < AdminController
   end
 
   def protocol_params
-    params.require(:protocol).permit(:name, :follow_up_days)
+    params.require(:protocol).permit(:name, :follow_up_days, :protocol_id)
   end
 end

--- a/app/controllers/admin/protocols_controller.rb
+++ b/app/controllers/admin/protocols_controller.rb
@@ -42,6 +42,31 @@ class Admin::ProtocolsController < AdminController
     redirect_to admin_protocols_url, notice: "Medication list was successfully deleted"
   end
 
+  def configure_coefficients
+    @coefficients = ProtocolDrugCalculationCoefficient.find_by(protocol_params[:id]).coefficients
+    if @coefficients.absent?
+      @coefficients = {
+        "load_coefficient": 0,
+      }
+      categories = Set.new
+      @protocol.protocol_drugs.each do |drug|
+        @coefficients[drug[:rxnorm_code]] = 0
+        categories.add(drug[:drug_category])
+      end
+      categories.each do |category|
+        @coefficients[category] = 0
+      end
+    end
+  end
+
+  def submit_coefficients
+    if @coefficients.save
+      redirect_to [:admin, @coefficients], notice: "Medication list was successfully configured"
+    else
+      render :configure_coefficients # renders with errors poopulated
+    end
+  end
+
   private
 
   def set_protocol

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -86,6 +86,9 @@ class Appointment < ApplicationRecord
     [0, (scheduled_date - device_created_at.to_date).to_i].max
   end
 
+  def protocol_id
+
+  end
   def scheduled?
     status.to_sym == :scheduled
   end

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -3,6 +3,8 @@ class Protocol < ApplicationRecord
 
   has_many :facility_groups
 
+  has_one :protocol_drug_calculation_coefficient
+
   before_create :assign_id
 
   validates :name, presence: true

--- a/app/models/protocol_drug_calculation_coefficient.rb
+++ b/app/models/protocol_drug_calculation_coefficient.rb
@@ -1,0 +1,4 @@
+class ProtocolDrugCalculationCoefficient < ApplicationRecord
+  belongs_to :protocol
+
+end

--- a/app/views/admin/protocols/edit.html.erb
+++ b/app/views/admin/protocols/edit.html.erb
@@ -1,2 +1,1 @@
 <h1>Edit medication list</h1>
-<%= render 'form', protocol: @protocol %>

--- a/app/views/admin/protocols/show.html.erb
+++ b/app/views/admin/protocols/show.html.erb
@@ -11,6 +11,7 @@
   <nav class="page-nav">
     <% if current_admin.accessible_organizations(:manage).any? || current_admin.power_user? %>
       <%= link_to "Edit medication list", edit_admin_protocol_path(@protocol), class: "btn btn-sm btn-outline-primary", id: "Edit medication list" %>
+      <%= link_to "Configure medication list", admin_protocol_configure_path(@protocol), class: "btn btn-sm btn-outline-primary", id: "Configure medication" %>
       <%= link_to new_admin_protocol_protocol_drug_path(@protocol), class: "btn btn-sm btn-success", id: "Add medication" do %>
         <i class="fas fa-plus mr-1"></i> Medication
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -245,7 +245,9 @@ Rails.application.routes.draw do
 
     resources :patient_imports, only: [:new, :create]
 
-    resources :protocols do
+    resources :protocols do # map get /configure to configure_coeffs and post /configure to submit_coeffs
+      get "/configure", to: "protocols#configure_coefficients"
+      post "/configure", to: "protocols#submit_coefficients"
       resources :protocol_drugs
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :protocols
   resources :home
 
   devise_scope :email_authentication do

--- a/db/migrate/20221208101407_create_protocol_drug_calculation_coefficients.rb
+++ b/db/migrate/20221208101407_create_protocol_drug_calculation_coefficients.rb
@@ -1,0 +1,10 @@
+class CreateProtocolDrugCalculationCoefficients < ActiveRecord::Migration[6.1]
+  def change
+    create_table :protocol_drug_calculation_coefficients do |t|
+      t.uuid :protocol_id
+      t.json :coefficients
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1495,6 +1495,38 @@ CREATE TABLE public.prescription_drugs (
 
 
 --
+-- Name: protocol_drug_calculation_coefficients; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.protocol_drug_calculation_coefficients (
+    id bigint NOT NULL,
+    protocol_id uuid,
+    coefficients json,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: protocol_drug_calculation_coefficients_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.protocol_drug_calculation_coefficients_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: protocol_drug_calculation_coefficients_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.protocol_drug_calculation_coefficients_id_seq OWNED BY public.protocol_drug_calculation_coefficients.id;
+
+
+--
 -- Name: protocol_drugs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -4502,6 +4534,13 @@ ALTER TABLE ONLY public.passport_authentications ALTER COLUMN id SET DEFAULT nex
 
 
 --
+-- Name: protocol_drug_calculation_coefficients id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.protocol_drug_calculation_coefficients ALTER COLUMN id SET DEFAULT nextval('public.protocol_drug_calculation_coefficients_id_seq'::regclass);
+
+
+--
 -- Name: treatment_group_memberships id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -4825,6 +4864,14 @@ ALTER TABLE ONLY public.phone_number_authentications
 
 ALTER TABLE ONLY public.prescription_drugs
     ADD CONSTRAINT prescription_drugs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: protocol_drug_calculation_coefficients protocol_drug_calculation_coefficients_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.protocol_drug_calculation_coefficients
+    ADD CONSTRAINT protocol_drug_calculation_coefficients_pkey PRIMARY KEY (id);
 
 
 --
@@ -6490,6 +6537,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20221010104304'),
 ('20221011064211'),
 ('20221011071921'),
-('20221011124316');
+('20221011124316'),
+('20221208101407');
 
 

--- a/spec/models/protocol_drug_calculation_coefficient_spec.rb
+++ b/spec/models/protocol_drug_calculation_coefficient_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ProtocolDrugCalculationCoefficient, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
**Story card:** [sc-XXXX](URL)

## Because

Currently, CVHOs send protocol coefficients to devs, who then manually add them to a config yaml. This feature will enable CVHOs to directly add/edit them from the dashboard

## This addresses

This PR adds a configure button to the protocol page, which opens up a view with fields to add protocol-level, drug-category-level and drug-level coefficients. Onn submission, the upadted coefficients will be reflected in the drug stock reports.

In case of errors in report calculation, a button to redirect the user to the correct protocol's `configure` page will pop up.

## Test instructions
WIP